### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "/personal-website-exp/",
   clearScreen: false,
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- configure Vite with `/personal-website-exp/` base so built assets load correctly on GitHub Pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aabdf438008326a0b1d88f0dc1d256