### PR TITLE
Fix GitHub Pages deployment for feature branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,7 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,5 +20,14 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- run build job for all branches
- deploy to GitHub Pages only when pushing to `main`

## Testing
- `bun install --frozen-lockfile` *(fails: GET https://registry.npmjs.org/... - 403)*
- `bun run build` *(fails: vite: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe5f10fc83288c02f726346d9226