### PR TITLE
fix: serve site from root path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/personal-website-exp/",
+  base: "/",
   clearScreen: false,
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- serve site from root path instead of `/personal-website-exp`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adcc8cd6308328963037f17dec869e