### PR TITLE
fix: use relative base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,10 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/",
+  // Use a relative base path so that assets load correctly
+  // when the site is served from a subdirectory or opened from
+  // the built `dist` folder without a dev server.
+  base: "./",
   clearScreen: false,
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- use a relative base path in Vite so assets load when site is served from a subdirectory or built output is opened directly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add05bc40883288d576d1c39936d93