### PR TITLE
fix: set router basename for github pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,9 @@ import DataDashboardCaseStudy from './pages/DataDashboardCaseStudy';
 import EconomicResearchCaseStudy from './pages/EconomicResearchCaseStudy';
 
 function App() {
+  const basename = import.meta.env.PROD ? '/personal-website-exp' : '/';
   return (
-    <Router>
+    <Router basename={basename}>
       <Layout>
         <Routes>
           <Route path="/" element={<Home />} />


### PR DESCRIPTION
## Summary
- ensure BrowserRouter uses the repository path as basename on GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf6f8db5883288714a2ef1b15fcc1