### PR TITLE
Add fallback 404 route to fix blank pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Contact from './pages/Contact';
 import CaseStudyUnitedWay from './pages/CaseStudyUnitedWay';
 import DataDashboardCaseStudy from './pages/DataDashboardCaseStudy';
 import EconomicResearchCaseStudy from './pages/EconomicResearchCaseStudy';
+import NotFound from './pages/NotFound';
 
 function App() {
   const basename = import.meta.env.PROD ? '/personal-website-exp' : '/';
@@ -23,6 +24,7 @@ function App() {
           <Route path="/work/united-way-marketing-analytics" element={<CaseStudyUnitedWay />} />
           <Route path="/work/data-dashboard-analytics" element={<DataDashboardCaseStudy />} />
           <Route path="/work/economic-research-analysis" element={<EconomicResearchCaseStudy />} />
+            <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 
 /**
@@ -6,6 +6,7 @@ import { useEffect } from "react";
  */
 const NotFound = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     console.error(
@@ -19,7 +20,7 @@ const NotFound = () => {
       <h1 className="text-4xl font-bold">404</h1>
       <p className="text-xl text-gray-600">Page not found</p>
       <button
-        onClick={() => (window.location.href = "/")}
+        onClick={() => navigate("/")}
         className="px-4 py-2 mt-8 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors"
       >
         Return home


### PR DESCRIPTION
## Summary
- add wildcard route to display custom 404 page
- enable navigating back home via react-router

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1e08654483289cd47da0d4b93495